### PR TITLE
Added data preparation utility

### DIFF
--- a/scripts/data_prep.py
+++ b/scripts/data_prep.py
@@ -11,9 +11,8 @@ features = (
     .get_column("features")
     .to_list()
 )
-# features = features[:20] 
-ids = ["id", "excntry", "eom", "eom_ret", "ret_exc_lead1m", "ctff_test"]
 df = pl.scan_parquet("data/raw/ctff_chars.parquet") # Change name from df to chars
+ids = ["id", "excntry", "eom", "eom_ret", "ret_exc_lead1m", "ctff_test"]
 group_cols = ["id", "excntry", "feature"]
 
 # Impute and rank
@@ -27,3 +26,11 @@ data_processed = impute_and_rank(
     group_cols=group_cols
 )
 print(f"Elapsed time: {time.perf_counter()-start_time:.6f} seconds") # 1000 sec for lazy API without streaming
+
+# Collect and save 
+(
+    data_processed
+    .collect(engine = 'streaming')
+    .write_parquet("data/processed/ctff_chars_processed.parquet")
+)
+

--- a/scripts/data_prep.py
+++ b/scripts/data_prep.py
@@ -13,7 +13,7 @@ features = (
 )
 df = pl.scan_parquet("data/raw/ctff_chars.parquet") # Change name from df to chars
 ids = ["id", "excntry", "eom", "eom_ret", "ret_exc_lead1m", "ctff_test"]
-group_cols = ["id", "excntry", "feature"]
+group_cols = ["excntry", "eom", "feature"]
 
 # Impute and rank
 start_time = time.perf_counter()

--- a/scripts/data_prep.py
+++ b/scripts/data_prep.py
@@ -1,0 +1,29 @@
+import time
+
+import polars as pl
+
+from utils.data_prep import impute_and_rank
+
+# Prepare input
+features = (
+    pl
+    .read_parquet("data/raw/ctff_features.parquet")
+    .get_column("features")
+    .to_list()
+)
+# features = features[:20] 
+ids = ["id", "excntry", "eom", "eom_ret", "ret_exc_lead1m", "ctff_test"]
+df = pl.scan_parquet("data/raw/ctff_chars.parquet") # Change name from df to chars
+group_cols = ["id", "excntry", "feature"]
+
+# Impute and rank
+start_time = time.perf_counter()
+data_processed = impute_and_rank(
+    df=df,
+    ids=ids,
+    features=features,
+    feat_prank=True,  
+    impute_flag=True,  
+    group_cols=group_cols
+)
+print(f"Elapsed time: {time.perf_counter()-start_time:.6f} seconds") # 1000 sec for lazy API without streaming

--- a/scripts/data_prep.py
+++ b/scripts/data_prep.py
@@ -27,10 +27,6 @@ data_processed = impute_and_rank(
 )
 print(f"Elapsed time: {time.perf_counter()-start_time:.6f} seconds") # 1000 sec for lazy API without streaming
 
-# Collect and save 
-(
-    data_processed
-    .collect(engine = 'streaming')
-    .write_parquet("data/processed/ctff_chars_processed.parquet")
-)
+# Save 
+data_processed.write_parquet("data/processed/ctff_chars_processed.parquet")
 

--- a/utils/data_prep.py
+++ b/utils/data_prep.py
@@ -67,4 +67,14 @@ def impute_and_rank(
                 value = pl.col('value').median().over(group_cols)
             )
 
-    return df.collect()
+    # Cast to wide format
+    df = (
+        df
+        .pivot(
+            index = ids,
+            on = "feature",
+            values = "value"
+        )
+    )
+
+    return df

--- a/utils/data_prep.py
+++ b/utils/data_prep.py
@@ -67,7 +67,8 @@ def impute_and_rank(
                 value = pl.col('value').median().over(group_cols)
             )
 
-    # Cast to wide format
+    # # Cast to wide format
+    df = df.collect() # Pivot doesn't work with LazyFrame
     df = (
         df
         .pivot(

--- a/utils/data_prep.py
+++ b/utils/data_prep.py
@@ -1,0 +1,70 @@
+import polars as pl
+
+
+def impute_and_rank(
+    df: pl.LazyFrame | pl.DataFrame,
+    ids: list[str],
+    features: list[str],
+    feat_prank: bool,
+    impute_flag: bool,
+    group_cols: list[str]
+) -> pl.DataFrame:
+    """
+    Master function to prepare prediction data.
+    1. Apply percentile ranks if feat_prank is True
+    2. Impute missing values based on feat_prank flag
+    """
+    # Pivot data to long format (and make sure that value is numeric)
+    df = (
+        df
+        .select(ids + features)  
+        .unpivot(
+            index = ids,        
+            on = features,  
+            variable_name = "feature", 
+            value_name = "value"
+        )
+        .cast({"value": pl.Float64})
+    )
+
+
+    # Percentile rank
+    if feat_prank:
+        df = (
+                df
+                .with_columns(
+                    zeroes = pl.col('value') == 0,
+                    prank_raw = (
+                        pl.col('value')
+                        .rank(method="max") # R uses "max" for ECDF, but maybe min is better?
+                        .over(group_cols) 
+                    ) / (
+                        pl.col('value')
+                        .count()
+                        .over(group_cols)
+                    )
+                )
+                .with_columns(
+                    # Set exact zeros to zero (value always return positive ranks)
+                    value = pl.when(pl.col('zeroes')).then(0).otherwise(pl.col('prank_raw'))
+                )
+                .drop("zeroes", "prank_raw")
+            )
+        # Center percentile ranks centered around 0
+        df = (
+            df
+            .with_columns(
+                value = pl.col("value") - 0.5
+            )
+        )
+    
+    # Imputation
+    if impute_flag and feat_prank:
+        df = df.fill_null(0)
+
+    if impute_flag and not feat_prank:
+        df = df.fill_null(
+                value = pl.col('value').median().over(group_cols)
+            )
+
+    return df.collect()


### PR DESCRIPTION
Added utils/data_prep.py which contains the function to the the percentile ranking and imputation scheme that we use for many of the methods. I also added script/data_prep.py, which runs the function and saves the data under data/processed/ctff_chars_processed.parquet. I thought we could use the latter for quicker prototyping 